### PR TITLE
closing div and remove unnecessary container

### DIFF
--- a/module.zpm
+++ b/module.zpm
@@ -25,7 +25,7 @@
 <@ Result @>
 <!-- Menu Start -->
 <div style="display: block;">
-    <div class="container" id="asTabs">
+    <div id="asTabs">
         <!-- Nav tabs -->
         <ul class="nav nav-tabs">
             <li><a href="#clients" data-toggle="tab"><: Clients :></a></li>
@@ -653,4 +653,5 @@
 </script>
 <br />
 <@ Copyright @>
+</div>
 </div>


### PR DESCRIPTION
Closing <div class="zmodule_content panel" id="zmodule_header_<@ ModuleName @>"> and removing unnecessary container class tag which messes up themes.
